### PR TITLE
Use the double quote character to quote PostgreSQL names

### DIFF
--- a/src/postgres.js
+++ b/src/postgres.js
@@ -6,6 +6,8 @@ squel.flavours['postgres'] = function(_squel) {
   cls.DefaultQueryBuilderOptions.numberedParametersStartAt = 1;
   cls.DefaultQueryBuilderOptions.autoQuoteAliasNames = false;
   cls.DefaultQueryBuilderOptions.useAsForTableAliasNames = true;
+  cls.DefaultQueryBuilderOptions.nameQuoteCharacter = '"';
+  cls.DefaultQueryBuilderOptions.tableAliasQuoteCharacter = '"';
 
   cls.PostgresOnConflictKeyUpdateBlock = class extends cls.AbstractSetFieldBlock {
     onConflict (conflictFields, fields) {

--- a/test/postgres.test.coffee
+++ b/test/postgres.test.coffee
@@ -308,8 +308,8 @@ test['Postgres flavour'] =
       autoQuoteFieldNames: false
       autoQuoteAliasNames: false
       useAsForTableAliasNames: true
-      nameQuoteCharacter: '`'
-      tableAliasQuoteCharacter: '`'
+      nameQuoteCharacter: '"'
+      tableAliasQuoteCharacter: '"'
       fieldAliasQuoteCharacter: '"'
       valueHandlers: []
       parameterCharacter: '?'


### PR DESCRIPTION
The backtick character (the core default) is MySQL specific and
non-standard. It's a syntax error in PostgreSQL.

See https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS

This PR is a copy of https://github.com/hiddentao/squel/pull/369/files on this fork.